### PR TITLE
Proper email address for Lars Christensen

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -562,7 +562,7 @@ christensen:
     name: Lars Næsbye Christensen
     home: DeIC
     country: "DK"
-    email: lanac@dtu.dk
+    email: lars.christensen@deic.dk
     role: Glenna Staff
     groups:
         - glenna 


### PR DESCRIPTION
lanac@dtu.dk is an alias associated with DTU, not DeIC... 
